### PR TITLE
feat: Update api-gateway-rest-api to 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ components:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
-| <a name="module_api_gateway_rest_api"></a> [api\_gateway\_rest\_api](#module\_api\_gateway\_rest\_api) | cloudposse/api-gateway/aws | 0.3.1 |
+| <a name="module_api_gateway_rest_api"></a> [api\_gateway\_rest\_api](#module\_api\_gateway\_rest\_api) | cloudposse/api-gateway/aws | 0.8.0 |
 | <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_nlb"></a> [nlb](#module\_nlb) | cloudposse/nlb/aws | 0.12.0 |

--- a/README.yaml
+++ b/README.yaml
@@ -60,7 +60,7 @@ description: |-
   | Name | Source | Version |
   |------|--------|---------|
   | <a name="module_acm"></a> [acm](#module\_acm) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
-  | <a name="module_api_gateway_rest_api"></a> [api\_gateway\_rest\_api](#module\_api\_gateway\_rest\_api) | cloudposse/api-gateway/aws | 0.3.1 |
+  | <a name="module_api_gateway_rest_api"></a> [api\_gateway\_rest\_api](#module\_api\_gateway\_rest\_api) | cloudposse/api-gateway/aws | 0.8.0 |
   | <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
   | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
   | <a name="module_nlb"></a> [nlb](#module\_nlb) | cloudposse/nlb/aws | 0.12.0 |

--- a/src/README.md
+++ b/src/README.md
@@ -64,7 +64,7 @@ components:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
-| <a name="module_api_gateway_rest_api"></a> [api\_gateway\_rest\_api](#module\_api\_gateway\_rest\_api) | cloudposse/api-gateway/aws | 0.3.1 |
+| <a name="module_api_gateway_rest_api"></a> [api\_gateway\_rest\_api](#module\_api\_gateway\_rest\_api) | cloudposse/api-gateway/aws | 0.8.0 |
 | <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_nlb"></a> [nlb](#module\_nlb) | cloudposse/nlb/aws | 0.12.0 |
@@ -91,7 +91,7 @@ components:
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br/>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_deregistration_delay"></a> [deregistration\_delay](#input\_deregistration\_delay) | The amount of time to wait in seconds before changing the state of a deregistering target to unused | `number` | `15` | no |
-| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br/>Map of maps. Keys are names of descriptors. Values are maps of the form<br/>`{<br/>  format = string<br/>  labels = list(string)<br/>}`<br/>(Type is `any` so the map values can later be enhanced to provide additional options.)<br/>`format` is a Terraform format string to be passed to the `format()` function.<br/>`labels` is a list of labels, in order, to pass to `format()` function.<br/>Label values will be normalized before being passed to `format()` so they will be<br/>identical to how they appear in `id`.<br/>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
+| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br/>Map of maps. Keys are names of descriptors. Values are maps of the form<br/>`{<br/>   format = string<br/>   labels = list(string)<br/>}`<br/>(Type is `any` so the map values can later be enhanced to provide additional options.)<br/>`format` is a Terraform format string to be passed to the `format()` function.<br/>`labels` is a list of labels, in order, to pass to `format()` function.<br/>Label values will be normalized before being passed to `format()` so they will be<br/>identical to how they appear in `id`.<br/>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
 | <a name="input_enable_private_link_nlb"></a> [enable\_private\_link\_nlb](#input\_enable\_private\_link\_nlb) | A flag to indicate whether to enable private link. | `bool` | `false` | no |
 | <a name="input_enable_private_link_nlb_deletion_protection"></a> [enable\_private\_link\_nlb\_deletion\_protection](#input\_enable\_private\_link\_nlb\_deletion\_protection) | A flag to indicate whether to enable private link deletion protection. | `bool` | `false` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
@@ -112,8 +112,11 @@ components:
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_rest_api_policy"></a> [rest\_api\_policy](#input\_rest\_api\_policy) | The IAM policy document for the API. | `string` | `null` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_stage_name"></a> [stage\_name](#input\_stage\_name) | The name of the stage | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+| <a name="input_throttling_burst_limit"></a> [throttling\_burst\_limit](#input\_throttling\_burst\_limit) | The API request burst limit | `number` | `-1` | no |
+| <a name="input_throttling_rate_limit"></a> [throttling\_rate\_limit](#input\_throttling\_rate\_limit) | The API request rate limit | `number` | `-1` | no |
 | <a name="input_xray_tracing_enabled"></a> [xray\_tracing\_enabled](#input\_xray\_tracing\_enabled) | A flag to indicate whether to enable X-Ray tracing. | `bool` | `true` | no |
 
 ## Outputs
@@ -134,4 +137,4 @@ components:
 - [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/main/modules/TODO) -
   Cloud Posse's upstream component
 
-[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-api-gateway-rest-api&utm_content=)
+[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/src/main.tf
+++ b/src/main.tf
@@ -10,7 +10,7 @@ locals {
 
 module "api_gateway_rest_api" {
   source  = "cloudposse/api-gateway/aws"
-  version = "0.3.1"
+  version = "0.8.0"
 
   enabled = local.enabled
 
@@ -22,6 +22,9 @@ module "api_gateway_rest_api" {
   access_log_format        = var.access_log_format
   rest_api_policy          = var.rest_api_policy
   private_link_target_arns = module.nlb[*].nlb_arn
+  stage_name               = var.stage_name
+  throttling_burst_limit   = var.throttling_burst_limit
+  throttling_rate_limit    = var.throttling_rate_limit
 
   context = module.this.context
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -132,3 +132,21 @@ variable "enable_private_link_nlb" {
   type        = bool
   default     = false
 }
+
+variable "stage_name" {
+  type        = string
+  default     = ""
+  description = "The name of the stage"
+}
+
+variable "throttling_burst_limit" {
+  description = "The API request burst limit"
+  type        = number
+  default     = -1
+}
+
+variable "throttling_rate_limit" {
+  description = "The API request rate limit"
+  type        = number
+  default     = -1
+}


### PR DESCRIPTION
## what

* Update to the lastest `terraform-aws-api-gateway` module version.
  * https://github.com/cloudposse/terraform-aws-api-gateway/releases/tag/v0.8.0

## why

* To be able to set the variables:
  * stage_name
  * throttling_burst_limit
  * throttling_rate_limit

## references

* Requires: https://github.com/cloudposse/terraform-aws-api-gateway/pull/58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the API gateway module to version `0.8.0`, reflecting the latest enhancements.
	- Introduced new configuration options for specifying the stage name and setting throttling limits for API requests, enabling more flexible control over API performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->