### PR TITLE
feat: add data_trace_enabled variable

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -18,6 +18,7 @@ module "api_gateway_rest_api" {
   endpoint_type            = var.endpoint_type
   logging_level            = var.logging_level
   metrics_enabled          = var.metrics_enabled
+  data_trace_enabled       = var.data_trace_enabled
   xray_tracing_enabled     = var.xray_tracing_enabled
   access_log_format        = var.access_log_format
   rest_api_policy          = var.rest_api_policy

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -39,6 +39,12 @@ variable "metrics_enabled" {
   default     = true
 }
 
+variable "data_trace_enabled" {
+  description = "Whether data trace logging is enabled for this method, which effects the log entries pushed to Amazon CloudWatch Logs."
+  type        = bool
+  default     = false
+}
+
 variable "xray_tracing_enabled" {
   description = "A flag to indicate whether to enable X-Ray tracing."
   type        = bool

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -40,7 +40,7 @@ variable "metrics_enabled" {
 }
 
 variable "data_trace_enabled" {
-  description = "Whether data trace logging is enabled for this method, which effects the log entries pushed to Amazon CloudWatch Logs."
+  description = "Whether data trace logging is enabled for this method, which affects the log entries pushed to Amazon CloudWatch Logs. WARNING: This logs full request/response data to CloudWatch and should not be enabled in production if sensitive data may be present in API payloads."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
## Summary
- Expose the `data_trace_enabled` attribute from the underlying `cloudposse/api-gateway/aws` module (v0.9.0)
- Adds a new `data_trace_enabled` variable (`bool`, default `false`) to `src/variables.tf`
- Passes the variable through to the module block in `src/main.tf`

This allows consumers of the component to control whether full request/response data is logged to CloudWatch Logs via `aws_api_gateway_method_settings`.

## Test plan
- [x] `terraform fmt -check src/` passes
- [ ] `terraform validate` in `src/` confirms no syntax errors
- [ ] Verify the attribute is correctly applied to the API Gateway method settings in a deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API Gateway now supports configurable data trace logging (controls full request/response entries sent to CloudWatch). Disabled by default.
  * Added a toggle with a warning: enabling data trace logging may expose sensitive payload data and is not recommended for production environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->